### PR TITLE
Use browser local storage for events before sending to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ __BROWSER__ && app.register(FetchToken, window.fetch);
 
 **Required. Browser-only.** See [https://github.com/fusionjs/fusion-tokens#fetchtoken](https://github.com/fusionjs/fusion-tokens#fetchtoken)
 
+##### `UniversalEventsBatchStorageToken`
+
+```js
+import {UniversalEventsBatchStorageToken, localBatchStorage} from 'fusion-plugin-universal-events';
+// ...
+__BROWSER__ && app.register(UniversalEventsBatchStorageToken, inMemoryBatchStorage);
+```
+
+**Optional. Browser-only.** 
+
+By default events will be stored in browser local storage before they are sent to the server.
+If you wish to override this behavior you can supply your own batch storage providing it complies with the `BatchStorage` interface type.
+
 ---
 
 #### Service API

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "clean": "rm -rf dist",
     "lint": "eslint . --ignore-path .gitignore",
     "transpile": "npm run clean && cup build",
-    "build-test": "rm -rf dist-test && cup build-tests",
+    "build-test": "rm -rf dist-tests && cup build-tests",
     "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js && node dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "prepublish": "npm run transpile"

--- a/src/browser.js
+++ b/src/browser.js
@@ -11,23 +11,27 @@ import {createPlugin} from 'fusion-core';
 import type {FusionPlugin} from 'fusion-core';
 import {FetchToken} from 'fusion-tokens';
 import type {Fetch} from 'fusion-tokens';
-
 import Emitter from './emitter.js';
 import type {
   IEmitter,
   UniversalEventsPluginDepsType as DepsType,
+  BatchStorage,
 } from './types.js';
+import {
+  UniversalEventsBatchStorageToken,
+  localBatchStorage,
+} from './storage/index.js';
 
 class UniversalEmitter extends Emitter {
-  batch: any;
   flush: any;
   fetch: any;
   interval: any;
+  storage: BatchStorage;
 
-  constructor(fetch: Fetch): void {
+  constructor(fetch: Fetch, storage: BatchStorage): void {
     super();
     //privates
-    this.batch = [];
+    this.storage = storage;
     this.flush = this.flushInternal.bind(this);
     this.fetch = fetch;
     this.setFrequency(5000);
@@ -40,38 +44,50 @@ class UniversalEmitter extends Emitter {
   emit(type: mixed, payload: mixed): void {
     payload = super.mapEvent(type, payload);
     super.handleEvent(type, payload);
-    this.batch.push({type, payload});
+    this.storage.add({type, payload});
   }
   // match server api
   from(): UniversalEmitter {
     return this;
   }
-  flushInternal(): void {
-    if (this.batch.length > 0) {
-      this.fetch('/_events', {
+  async flushInternal(): Promise<void> {
+    const items = this.storage.getAndClear();
+    if (items.length === 0) return;
+
+    try {
+      const res = await this.fetch('/_events', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({items: this.batch} || []),
-      }).catch(() => {});
+        body: JSON.stringify({items}),
+      });
+
+      if (!res.ok) {
+        // sending failed so put the logs back into storage
+        this.storage.addToStart(...items);
+      }
+    } catch (e) {
+      // sending failed so put the logs back into storage
+      this.storage.addToStart(...items);
     }
-    this.batch = [];
   }
   teardown(): void {
     window.removeEventListener('beforeunload', this.flush);
     clearInterval(this.interval);
     this.interval = null;
-    this.batch = [];
   }
 }
 
 const plugin =
   __BROWSER__ &&
   createPlugin({
-    deps: {fetch: FetchToken},
-    provides: ({fetch}) => {
-      return new UniversalEmitter(fetch);
+    deps: {
+      fetch: FetchToken,
+      storage: UniversalEventsBatchStorageToken.optional,
+    },
+    provides: ({fetch, storage}) => {
+      return new UniversalEmitter(fetch, storage || localBatchStorage);
     },
     cleanup: async emitter => {
       return emitter.teardown();

--- a/src/index.js
+++ b/src/index.js
@@ -24,3 +24,5 @@ export default ((UniversalEventsPlugin: any): FusionPlugin<DepsType, IEmitter>);
 export const UniversalEventsToken: Token<IEmitter> = createToken(
   'UniversalEventsToken'
 );
+
+export * from './storage/index.js';

--- a/src/storage/__tests__/storage-test.browser.js
+++ b/src/storage/__tests__/storage-test.browser.js
@@ -1,0 +1,60 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import test from 'tape-cup';
+import {inMemoryBatchStorage, localBatchStorage} from '../index.js';
+
+const toBeTested = {
+  localBatchStorage,
+  inMemoryBatchStorage,
+};
+
+Object.keys(toBeTested).forEach(storageType => {
+  const {add, addToStart, getAndClear} = toBeTested[storageType];
+
+  test(storageType, t => {
+    t.test('add', t => {
+      const data = {type: 'nick', payload: 'test'};
+      getAndClear();
+      add(data);
+      t.deepEqual(getAndClear(), [data], 'add should add to storage');
+      t.end();
+    });
+
+    t.test('addToStart', t => {
+      const data1 = {type: '1', payload: 'test'};
+      const data2 = {type: '2', payload: 'test'};
+      getAndClear();
+      add(data1);
+      addToStart(data2);
+
+      t.deepEqual(
+        getAndClear(),
+        [data2, data1],
+        'addToStart should add to beginning of array'
+      );
+      t.end();
+    });
+
+    t.test('getAndClear', t => {
+      const data = {type: 'nick', payload: 'test'};
+      getAndClear();
+      add(data);
+
+      t.deepEqual(
+        getAndClear(),
+        [data],
+        'getAndClear should get current array'
+      );
+      t.notOk(getAndClear().length, 'and clear it');
+      t.end();
+    });
+
+    t.end();
+  });
+});

--- a/src/storage/in-memory.js
+++ b/src/storage/in-memory.js
@@ -1,0 +1,23 @@
+// @flow
+
+import type {BatchStorage, BatchType} from '../types';
+
+class InMemoryBatchStorage implements BatchStorage {
+  data = [];
+
+  add = (...toBeAdded: BatchType[]) => {
+    this.data.push(...toBeAdded);
+  };
+
+  addToStart = (...toBeAdded: BatchType[]) => {
+    this.data.unshift(...toBeAdded);
+  };
+
+  getAndClear = () => {
+    const events = this.data;
+    this.data = [];
+    return events;
+  };
+}
+
+export const inMemoryBatchStorage = new InMemoryBatchStorage();

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,0 +1,12 @@
+// @flow
+
+import type {Token} from 'fusion-core';
+import type {BatchStorage} from '../types';
+import {createToken} from 'fusion-core';
+
+export const UniversalEventsBatchStorageToken: Token<
+  BatchStorage
+> = createToken('UniversalEventsBatchStorageToken');
+
+export {inMemoryBatchStorage} from './in-memory.js';
+export {localBatchStorage} from './local-storage.js';

--- a/src/storage/local-storage.js
+++ b/src/storage/local-storage.js
@@ -1,0 +1,63 @@
+// @flow
+/* global window */
+
+import type {BatchType, BatchStorage} from '../types';
+import {inMemoryBatchStorage} from './in-memory';
+
+const storageKey = 'fusion-events';
+
+const get = () => {
+  try {
+    const events = JSON.parse(window.localStorage.getItem(storageKey));
+    return Array.isArray(events) ? events : [];
+  } catch (e) {
+    return [];
+  }
+};
+
+const clear = () => {
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch (e) {
+    // do nothing
+  }
+};
+
+const set = (events: BatchType[]) => {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(events));
+  } catch (e) {
+    // storage might be full, do nothing
+  }
+};
+
+class LocalBatchStorage implements BatchStorage {
+  add = (...toBeAdded: BatchType[]) => {
+    set(toBeAdded.concat(get()));
+  };
+
+  addToStart = (...toBeAdded: BatchType[]) => {
+    set(toBeAdded.concat(get()));
+  };
+
+  getAndClear = () => {
+    const events = get();
+    clear();
+    return events;
+  };
+}
+
+let isLocalStorageWritable = true;
+
+try {
+  window.localStorage.setItem('test', 'test');
+  window.localStorage.removeItem('test');
+} catch (e) {
+  // if set/remove item fails localStorage is not writable
+  // fallback to in-memory storage
+  isLocalStorageWritable = false;
+}
+
+export const localBatchStorage = isLocalStorageWritable
+  ? new LocalBatchStorage()
+  : inMemoryBatchStorage;

--- a/src/types.js
+++ b/src/types.js
@@ -33,6 +33,17 @@ export interface IEmitter {
   flush(): void;
 }
 
+export type BatchType = {|
+  type: mixed,
+  payload: mixed,
+|};
+
+export interface BatchStorage {
+  add(toBeAdded: BatchType): void;
+  addToStart(toBeAdded: BatchType): void;
+  getAndClear(): BatchType[];
+}
+
 export type UniversalEventsPluginDepsType = {
   fetch: typeof FetchToken,
 };


### PR DESCRIPTION
- added local-storage for more resilient batch storage (now the default)
- users can use `UniversalEventsBatchStorageToken` to override batch store 


continued from #145