### PR TITLE
Use visibility API instead of beforeunload

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `fusion-plugin-universal-events` is commonly required by other Fusion.js plu
 
 It's useful for when you want to collect data about user actions or other metrics, and send them in bulk to the server to minimize the number of HTTP requests.
 
-For convenience, this plugin automatically flushes its queue before page unload on `document.hidden`.
+For convenience, this plugin automatically flushes its queue before page unload on `document.visibilityState === 'hidden'`.
 
 If you need to use the universal event emitter from React, use [`fusion-plugin-universal-events-react`](https://github.com/fusionjs/fusion-plugin-universal-events-react)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `fusion-plugin-universal-events` is commonly required by other Fusion.js plu
 
 It's useful for when you want to collect data about user actions or other metrics, and send them in bulk to the server to minimize the number of HTTP requests.
 
-For convenience, this plugin automatically flushes its queue on page unload.
+For convenience, this plugin automatically flushes its queue before page unload on `document.hidden`.
 
 If you need to use the universal event emitter from React, use [`fusion-plugin-universal-events-react`](https://github.com/fusionjs/fusion-plugin-universal-events-react)
 

--- a/src/__tests__/test.browser.js
+++ b/src/__tests__/test.browser.js
@@ -21,8 +21,8 @@ import {
   inMemoryBatchStorage as store,
 } from '../storage/index.js';
 
-// Set document.hidden to test flushBeforeTerminated
-Object.defineProperty(document, 'hidden', {value: true});
+// Set document.visibilityState to test flushBeforeTerminated
+Object.defineProperty(document, 'visibilityState', {value: 'hidden'});
 const visibilitychangeEvent = new Event('visibilitychange');
 
 /* Test helpers */

--- a/src/__tests__/test.browser.js
+++ b/src/__tests__/test.browser.js
@@ -22,12 +22,8 @@ import {
 } from '../storage/index.js';
 
 // Set document.hidden to test flushBeforeTerminated
-Object.defineProperty(document, 'hidden', {
-  configurable: true,
-  get: function() {
-    return true;
-  },
-});
+Object.defineProperty(document, 'hidden', {value: true});
+const visibilitychangeEvent = new Event('visibilitychange');
 
 /* Test helpers */
 function getApp(fetch: Fetch) {
@@ -91,7 +87,7 @@ test('Browser EventEmitter', async t => {
         emitted = true;
       });
       emitter.emit('a', {x: 1});
-      emitter.flushBeforeTerminated();
+      window.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -116,7 +112,7 @@ test('Browser EventEmitter adds events back to queue if they fail to send', asyn
       const emitter = events.from(ctx);
       t.equal(emitter, events);
       emitter.emit('a', {x: 1});
-      emitter.flushBeforeTerminated();
+      window.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };
@@ -139,7 +135,7 @@ test('Browser EventEmitter adds events back to queue if they fail to send 2', as
       const emitter = events.from(ctx);
       t.equal(emitter, events);
       emitter.emit('a', {x: 1});
-      emitter.flushBeforeTerminated();
+      window.dispatchEvent(visibilitychangeEvent);
       emitter.teardown();
       return next();
     };

--- a/src/__tests__/test.browser.js
+++ b/src/__tests__/test.browser.js
@@ -6,6 +6,7 @@
  * @flow
  */
 
+/* eslint-env browser */
 import test from 'tape-cup';
 
 import App from 'fusion-core';
@@ -19,6 +20,14 @@ import {
   UniversalEventsBatchStorageToken,
   inMemoryBatchStorage as store,
 } from '../storage/index.js';
+
+// Set document.hidden to test flushBeforeTerminated
+Object.defineProperty(document, 'hidden', {
+  configurable: true,
+  get: function() {
+    return true;
+  },
+});
 
 /* Test helpers */
 function getApp(fetch: Fetch) {
@@ -82,7 +91,7 @@ test('Browser EventEmitter', async t => {
         emitted = true;
       });
       emitter.emit('a', {x: 1});
-      emitter.flush();
+      emitter.flushBeforeTerminated();
       emitter.teardown();
       return next();
     };
@@ -107,7 +116,7 @@ test('Browser EventEmitter adds events back to queue if they fail to send', asyn
       const emitter = events.from(ctx);
       t.equal(emitter, events);
       emitter.emit('a', {x: 1});
-      emitter.flush();
+      emitter.flushBeforeTerminated();
       emitter.teardown();
       return next();
     };
@@ -130,7 +139,7 @@ test('Browser EventEmitter adds events back to queue if they fail to send 2', as
       const emitter = events.from(ctx);
       t.equal(emitter, events);
       emitter.emit('a', {x: 1});
-      emitter.flush();
+      emitter.flushBeforeTerminated();
       emitter.teardown();
       return next();
     };

--- a/src/browser.js
+++ b/src/browser.js
@@ -35,7 +35,7 @@ class UniversalEmitter extends Emitter {
     this.flush = this.flushInternal.bind(this);
     this.fetch = fetch;
     this.setFrequency(5000);
-    window.addEventListener('beforeunload', this.flush);
+    window.addEventListener('visibilitychange', this.flushBeforeTerminated);
   }
   setFrequency(frequency: number): void {
     window.clearInterval(this.interval);
@@ -50,6 +50,11 @@ class UniversalEmitter extends Emitter {
   from(): UniversalEmitter {
     return this;
   }
+  flushBeforeTerminated = () => {
+    if (document.hidden) {
+      this.flushInternal();
+    }
+  };
   async flushInternal(): Promise<void> {
     const items = this.storage.getAndClear();
     if (items.length === 0) return;
@@ -73,7 +78,7 @@ class UniversalEmitter extends Emitter {
     }
   }
   teardown(): void {
-    window.removeEventListener('beforeunload', this.flush);
+    window.removeEventListener('visibilitychange', this.flushBeforeTerminated);
     clearInterval(this.interval);
     this.interval = null;
   }

--- a/src/browser.js
+++ b/src/browser.js
@@ -39,7 +39,7 @@ class UniversalEmitter extends Emitter {
   }
   setFrequency(frequency: number): void {
     window.clearInterval(this.interval);
-    this.interval = setInterval(this.flush, frequency);
+    this.interval = setInterval(this.flushInternal, frequency);
   }
   emit(type: mixed, payload: mixed): void {
     payload = super.mapEvent(type, payload);

--- a/src/browser.js
+++ b/src/browser.js
@@ -52,7 +52,7 @@ class UniversalEmitter extends Emitter {
   }
   flushBeforeTerminated = () => {
     if (document.hidden) {
-      this.flushInternal();
+      return this.flushInternal();
     }
   };
   async flushInternal(): Promise<void> {
@@ -91,12 +91,9 @@ const plugin =
       fetch: FetchToken,
       storage: UniversalEventsBatchStorageToken.optional,
     },
-    provides: ({fetch, storage}) => {
-      return new UniversalEmitter(fetch, storage || localBatchStorage);
-    },
-    cleanup: async emitter => {
-      return emitter.teardown();
-    },
+    provides: ({fetch, storage}) =>
+      new UniversalEmitter(fetch, storage || localBatchStorage),
+    cleanup: async emitter => emitter.teardown(),
   });
 
 export default ((plugin: any): FusionPlugin<DepsType, IEmitter>);

--- a/src/browser.js
+++ b/src/browser.js
@@ -51,7 +51,7 @@ class UniversalEmitter extends Emitter {
     return this;
   }
   flushBeforeTerminated = () => {
-    if (document.hidden) {
+    if (document.visibilityState === 'hidden') {
       return this.flushInternal();
     }
   };

--- a/src/browser.js
+++ b/src/browser.js
@@ -88,9 +88,12 @@ const plugin =
       fetch: FetchToken,
       storage: UniversalEventsBatchStorageToken.optional,
     },
-    provides: ({fetch, storage}) =>
-      new UniversalEmitter(fetch, storage || localBatchStorage),
-    cleanup: async emitter => emitter.teardown(),
+    provides: ({fetch, storage}) => {
+      return new UniversalEmitter(fetch, storage || localBatchStorage);
+    },
+    cleanup: async emitter => {
+      return emitter.teardown();
+    },
   });
 
 export default ((plugin: any): FusionPlugin<DepsType, IEmitter>);

--- a/src/browser.js
+++ b/src/browser.js
@@ -50,11 +50,8 @@ class UniversalEmitter extends Emitter {
   from(): UniversalEmitter {
     return this;
   }
-  flushBeforeTerminated = () => {
-    if (document.visibilityState === 'hidden') {
-      return this.flushInternal();
-    }
-  };
+  flushBeforeTerminated = () =>
+    document.visibilityState === 'hidden' && this.flushInternal();
   async flushInternal(): Promise<void> {
     const items = this.storage.getAndClear();
     if (items.length === 0) return;


### PR DESCRIPTION
Using the `beforeunload` event prevents browsers from caching the page
in the page navigation cache:

https://developers.google.com/web/updates/2018/07/page-lifecycle-api#the-beforeunload-event

Page Visibility is a better alternative. This API is widely supported
except for old Android, where it's prefixed on 4.4 and unavailable on
lower versions. I'm happy to add fallbacks if any reviewers feel they're
necessary.