### PR TITLE
Release v1.3.1-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "fusion-plugin-universal-events",
   "description": "Events Emitter",
-  "version": "1.3.1-0",
+  "version": "1.3.1-1",
   "repository": "fusionjs/fusion-plugin-universal-events",
   "keywords": [],
   "license": "MIT",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",
   "browser": {
@@ -51,8 +54,7 @@
     "lint": "eslint . --ignore-path .gitignore",
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-tests && cup build-tests",
-    "just-test":
-      "node_modules/.bin/unitest --browser=dist-tests/browser.js && node dist-tests/node.js",
+    "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js && node dist-tests/node.js",
     "test": "npm run build-test && npm run just-test",
     "prepublish": "npm run transpile"
   },


### PR DESCRIPTION
- Use visibility API instead of beforeunload ([#158](https://github.com/fusionjs/fusion-plugin-universal-events/pull/158))
- Update dependency fusion-core to v1.10.1 ([#168](https://github.com/fusionjs/fusion-plugin-universal-events/pull/168))